### PR TITLE
removed intern and assume-no-moving-gc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,11 @@ go 1.18
 
 require (
 	github.com/dvyukov/go-fuzz v0.0.0-20210103155950-6a8e9d1f2415
-	go4.org/intern v0.0.0-20211027215823-ae77deb06f29
 	honnef.co/go/tools v0.3.2
 )
 
 require (
 	github.com/BurntSushi/toml v0.4.1 // indirect
-	go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,11 +2,6 @@ github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/dvyukov/go-fuzz v0.0.0-20210103155950-6a8e9d1f2415 h1:q1oJaUPdmpDm/VyXosjgPgr6wS7c5iV2p0PwJD73bUI=
 github.com/dvyukov/go-fuzz v0.0.0-20210103155950-6a8e9d1f2415/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
-go4.org/intern v0.0.0-20211027215823-ae77deb06f29 h1:UXLjNohABv4S58tHmeuIZDO6e3mHpW2Dx33gaNt03LE=
-go4.org/intern v0.0.0-20211027215823-ae77deb06f29/go.mod h1:cS2ma+47FKrLPdXFpr7CuxiTW3eyJbWew4qx0qtQWDA=
-go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
-go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 h1:FyBZqvoA/jbNzuAWLQE2kG820zMAkcilx6BMjGbL/E4=
-go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e h1:qyrTQ++p1afMkO4DPEeLGq/3oTsdlvdH4vqZUBWzUKM=
 golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=

--- a/netipx_test.go
+++ b/netipx_test.go
@@ -14,8 +14,6 @@ import (
 	"net/netip"
 	"reflect"
 	"testing"
-
-	"go4.org/intern"
 )
 
 type (
@@ -729,7 +727,6 @@ var (
 	sinkIPPrefix      IPPrefix
 	sinkIPPrefixSlice []IPPrefix
 	sinkIPRange       IPRange
-	sinkInternValue   *intern.Value
 	sinkIP16          [16]byte
 	sinkIP4           [4]byte
 	sinkBool          bool


### PR DESCRIPTION
i recently found out that my builds was broken by `inetaf/netaddr` after updating to go 1.19, the error was because of an outdated `assume-no-moving-gc` package.

ok this was easy to solve since 1.19 was added to the allowlist in `assume-no-moving-gc`, but it would be nice to not have this problems on updates. I really like the solution of `netipx` of reimplementing the builder(etc..) for the new `netip` package.

I checked the codebase and `assume-no-moving-gc` was imported by the `go4.org/intern` package, in `netipx` the `intern` package is now only used in a single testfile `netipx_test.go` and seems to be deprecated.
