### PR TITLE
Remove redundant IPv4-in-IPv6 check in FromStdIPRaw

### DIFF
--- a/netipx.go
+++ b/netipx.go
@@ -29,10 +29,7 @@ import (
 // FromStdIPRaw.
 func FromStdIP(std net.IP) (ip netip.Addr, ok bool) {
 	ret, ok := FromStdIPRaw(std)
-	if ret.Is4In6() {
-		ret = ret.Unmap()
-	}
-	return ret, ok
+	return ret.Unmap(), ok
 }
 
 // FromStdIPRaw returns an IP from the standard library's IP type.


### PR DESCRIPTION
`netip.Addr.Unmap` already checks `netip.Addr.Is4In6` and only unmaps the address in case it is an IPv4-in-IPv6 address.