### PR TITLE
CI updates for Go 1.19

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Check Go modules
       if: matrix.go-version == '1.17'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         # Oldest we support is 1.18
-        go-version: [1.18]
+        go-version: [1.18, 1.19]
     runs-on: ubuntu-latest
 
     steps:
@@ -27,13 +27,13 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Check Go modules
-      if: matrix.go-version == '1.17'
+      if: matrix.go-version == '1.19'
       run: |
         go mod tidy
         git diff --exit-code
 
     - name: Check formatting
-      if: matrix.go-version == '1.17'
+      if: matrix.go-version == '1.19'
       run: diff -u <(echo -n) <(gofmt -d .)
 
     - name: Run tests on linux

--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Check out code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Print staticcheck version
       run: go run honnef.co/go/tools/cmd/staticcheck -version

--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Check out code
       uses: actions/checkout@v3


### PR DESCRIPTION
Run tests using Go 1.19 and update GitHub actions to latest versions.