### PR TITLE
Add AddrIPNet

### DIFF
--- a/netipx.go
+++ b/netipx.go
@@ -142,7 +142,21 @@ func PrefixIPNet(p netip.Prefix) *net.IPNet {
 	}
 	return &net.IPNet{
 		IP:   p.Addr().AsSlice(),
-		Mask: net.CIDRMask(int(p.Bits()), int(p.Addr().BitLen())),
+		Mask: net.CIDRMask(p.Bits(), p.Addr().BitLen()),
+	}
+}
+
+// AddrIPNet returns the net.IPNet representation of an netip.Addr
+// with a mask corresponding to the addresses's bit length.
+// The returned value is always non-nil.
+// Any zone identifier is dropped in the conversion.
+func AddrIPNet(addr netip.Addr) *net.IPNet {
+	if !addr.IsValid() {
+		return &net.IPNet{}
+	}
+	return &net.IPNet{
+		IP:   addr.AsSlice(),
+		Mask: net.CIDRMask(addr.BitLen(), addr.BitLen()),
 	}
 }
 

--- a/netipx_test.go
+++ b/netipx_test.go
@@ -181,6 +181,47 @@ func TestIPPrefixIsSingleIP(t *testing.T) {
 	}
 }
 
+func TestAddrIPNet(t *testing.T) {
+	tests := []struct {
+		name string
+		addr netip.Addr
+		want *net.IPNet
+	}{
+		{
+			name: "invalid IP",
+			addr: netip.Addr{},
+			want: &net.IPNet{},
+		},
+		{
+			name: "IPv4",
+			addr: mustIP("127.0.0.1"),
+			want: &net.IPNet{
+				IP:   net.IPv4(127, 0, 0, 1).To4(),
+				Mask: net.IPv4Mask(255, 255, 255, 255),
+			},
+		},
+		{
+			name: "IPv6",
+			addr: mustIP("2001:db8::"),
+			want: &net.IPNet{
+				IP:   net.ParseIP("2001:db8::"),
+				Mask: net.CIDRMask(128, 128),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AddrIPNet(tt.addr)
+			if got == nil {
+				t.Fatalf("nil result")
+			} else if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AddrIPNet(%q) = %+v; want %+v", tt.addr, got, tt.want)
+			}
+		})
+	}
+
+}
+
 type appendMarshaler interface {
 	encoding.TextMarshaler
 	AppendTo([]byte) []byte


### PR DESCRIPTION
Similar to PrefixIPNet, AddrIPNet returns the net.IPNet representation of an netip.Addr. The mask corresponds to the addresses's bit length.

This was copied from Cilium's pkg/ip/AddrToIPNet [1] and changed to always return a non-nil value.

[1] https://github.com/cilium/cilium/blob/13cdd07a70ffd21df3cc043a7c24334985c11286/pkg/ip/cidr.go#L74-L84