### PR TITLE
Clean up tests

### DIFF
--- a/netipx_test.go
+++ b/netipx_test.go
@@ -139,27 +139,6 @@ func TestFromStdIPNet(t *testing.T) {
 	}
 }
 
-func TestIPPrefixIsSingleIP(t *testing.T) {
-	tests := []struct {
-		ipp  IPPrefix
-		want bool
-	}{
-		{ipp: mustIPPrefix("127.0.0.1/32"), want: true},
-		{ipp: mustIPPrefix("127.0.0.1/31"), want: false},
-		{ipp: mustIPPrefix("127.0.0.1/0"), want: false},
-		{ipp: mustIPPrefix("::1/128"), want: true},
-		{ipp: mustIPPrefix("::1/127"), want: false},
-		{ipp: mustIPPrefix("::1/0"), want: false},
-		{ipp: IPPrefix{}, want: false},
-	}
-	for _, tt := range tests {
-		got := tt.ipp.IsSingleIP()
-		if got != tt.want {
-			t.Errorf("IsSingleIP(%v) = %v want %v", tt.ipp, got, tt.want)
-		}
-	}
-}
-
 func TestAddrIPNet(t *testing.T) {
 	tests := []struct {
 		name string

--- a/netipx_test.go
+++ b/netipx_test.go
@@ -768,8 +768,6 @@ func TestNoAllocs(t *testing.T) {
 	// IP constructors
 	test("FromStdIP", func() { sinkIP = panicIPOK(FromStdIP(net.IP([]byte{1, 2, 3, 4}))) })
 	test("FromStdIPRaw", func() { sinkIP = panicIPOK(FromStdIPRaw(net.IP([]byte{1, 2, 3, 4}))) })
-	test("IPv6LinkLocalAllNodes", func() { sinkIP = netip.IPv6LinkLocalAllNodes() })
-	test("IPv6Unspecified", func() { sinkIP = netip.IPv6Unspecified() })
 
 	// IPPort constructors
 	test("FromStdAddr", func() {

--- a/netipx_test.go
+++ b/netipx_test.go
@@ -27,27 +27,6 @@ func IPv4(a, b, c, d uint8) IP {
 	return netip.AddrFrom4([4]byte{a, b, c, d})
 }
 
-// IPv6Raw returns the IPv6 address given by the bytes in addr,
-// without an implicit Unmap call to unmap any v6-mapped IPv4
-// address.
-func IPv6Raw(addr [16]byte) IP {
-	return netip.AddrFrom16(addr)
-}
-
-// IPFrom16 returns the IP address given by the bytes in addr,
-// unmapping any v6-mapped IPv4 address.
-//
-// It is equivalent to calling IPv6Raw(addr).Unmap().
-func IPFrom16(addr [16]byte) IP {
-	return netip.AddrFrom16(addr).Unmap()
-}
-
-// IPFrom4 returns the IPv4 address given by the bytes in addr.
-// It is equivalent to calling IPv4(addr[0], addr[1], addr[2], addr[3]).
-func IPFrom4(addr [4]byte) IP {
-	return IPv4(addr[0], addr[1], addr[2], addr[3])
-}
-
 var long = flag.Bool("long", false, "run long tests")
 
 func TestFromStdIP(t *testing.T) {
@@ -67,7 +46,7 @@ func TestFromStdIP(t *testing.T) {
 			name: "v6",
 			fn:   FromStdIP,
 			std:  net.ParseIP("::1"),
-			want: IPv6Raw([...]byte{15: 1}),
+			want: netip.AddrFrom16([...]byte{15: 1}),
 		},
 		{
 			name: "4in6-unmap",
@@ -85,7 +64,7 @@ func TestFromStdIP(t *testing.T) {
 			name: "4in6-raw",
 			fn:   FromStdIPRaw,
 			std:  net.ParseIP("1.2.3.4"),
-			want: IPv6Raw([...]byte{10: 0xff, 11: 0xff, 12: 1, 13: 2, 14: 3, 15: 4}),
+			want: netip.AddrFrom16([...]byte{10: 0xff, 11: 0xff, 12: 1, 13: 2, 14: 3, 15: 4}),
 		},
 		{
 			name: "bad-raw",
@@ -722,7 +701,7 @@ func TestAddrNextPrior(t *testing.T) {
 
 	for _, ip := range []IP{
 		mustIP("255.255.255.255"),
-		IPv6Raw(allFF),
+		netip.AddrFrom16(allFF),
 	} {
 		got := ip.Next()
 		if got.IsValid() {


### PR DESCRIPTION
- [Replace and remove test helpers](https://github.com/go4org/netipx/commit/8894773969fd190286c98fbffd926bc2f24789a9)
- [Remove TestIPPrefixIsSingleIP](https://github.com/go4org/netipx/commit/55f0df17fa43b2432657645a0e47f52e94fb9a77)
- [Remove functions covered in net/netip from TestNoAllocs](https://github.com/go4org/netipx/commit/08c63753a3439f7af4481dcd50d0592e0172345a)

See individual commit messages for details.